### PR TITLE
Add offline ChatGPT helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # ABDUL-QASSIM
+
+This repository contains example scripts for working with your own
+ChatGPT data and local text notes. The goal is to experiment with a
+completely offline workflow where a custom bot can answer questions
+using your personal knowledge base.
+
+## Getting your ChatGPT history
+
+1. In ChatGPT, open **Settings & Beta** → **Data Controls**.
+2. Choose **Export Data**. You will receive a ZIP archive containing a
+   JSON file with your conversation history.
+3. Unzip the archive and note the path to the `*.json` file.
+
+To convert the exported history into individual text files, run:
+
+```bash
+python scripts/parse_history.py path/to/conversations.json history/
+```
+
+This will create one text file per conversation under the `history/`
+directory.
+
+## Using your own notes
+
+Place any `.txt` files you want the bot to reference inside a directory,
+e.g. `notes/`. Each file can contain sentences or bullet points.
+
+The `offline_bot.py` script performs a very simple keyword search across
+those files:
+
+```bash
+python scripts/offline_bot.py notes "your question here"
+```
+
+The script prints the sentences that match all the keywords in your
+question. This is only a starting point. You can extend it with a local
+language model or embedding-based search to improve the quality of the
+answers.
+
+## Custom training
+
+If you wish to build a more advanced model, you can fine-tune an
+open-source language model (such as LLaMA, GPT-J, or similar) using your
+own dataset. The exported conversations and your notes can serve as the
+training data. Refer to the documentation of the model you choose for
+fine-tuning instructions.
+
+These scripts are intentionally lightweight so they can run without any
+network connection once the required Python packages are installed.

--- a/scripts/offline_bot.py
+++ b/scripts/offline_bot.py
@@ -1,0 +1,63 @@
+"""
+offline_bot.py
+---------------
+
+A minimal example of using your own text files to answer questions
+without any online search. This script loads all ``.txt`` files from a
+specified directory and uses simple keyword matching to return the most
+relevant sentences for a query.
+
+This is **not** a full language model. It simply performs a very basic
+search. You can extend it by integrating an open-source language model or
+embedding-based retrieval library (e.g. `sentence-transformers`).
+
+Usage::
+
+    python offline_bot.py data_dir "your question here"
+
+"""
+import sys
+from pathlib import Path
+import re
+
+
+def load_sentences(data_dir):
+    """Load sentences from all .txt files under data_dir."""
+    sentences = []
+    for path in Path(data_dir).rglob('*.txt'):
+        text = path.read_text(encoding='utf-8')
+        for line in text.splitlines():
+            line = line.strip()
+            if line:
+                sentences.append((path.name, line))
+    return sentences
+
+
+def simple_search(sentences, query):
+    """Return sentences containing all keywords from the query."""
+    keywords = re.findall(r"\w+", query.lower())
+    results = []
+    for name, sentence in sentences:
+        s_lower = sentence.lower()
+        if all(word in s_lower for word in keywords):
+            results.append((name, sentence))
+    return results
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Usage: python offline_bot.py data_dir "question"')
+        return
+    data_dir = sys.argv[1]
+    query = ' '.join(sys.argv[2:])
+    sentences = load_sentences(data_dir)
+    results = simple_search(sentences, query)
+    if not results:
+        print('No results found.')
+    else:
+        for name, sentence in results[:5]:
+            print(f'[{name}] {sentence}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/parse_history.py
+++ b/scripts/parse_history.py
@@ -1,0 +1,76 @@
+"""
+parse_history.py
+-----------------
+
+This script loads ChatGPT conversation history exported using the
+"Export data" option from your ChatGPT settings. The exported file is a JSON
+archive. This script extracts the conversations and saves them in a more
+convenient format such as plain text files.
+
+Usage:
+    python parse_history.py path_to_export.json output_dir
+
+The export file typically has a structure like::
+
+    {
+        "conversations": [
+            {
+                "title": "My conversation",
+                "mapping": { ... }
+            },
+            ...
+        ]
+    }
+
+The `mapping` field contains the messages. This script walks the mapping
+and writes each conversation to ``output_dir/<title>.txt``.
+
+You need Python 3.8+.
+"""
+import json
+import sys
+from pathlib import Path
+
+def extract_text_from_mapping(mapping):
+    """Yield message texts in order from a conversation mapping."""
+    # Each mapping entry is keyed by message ID with info about parent
+    # relationships. We iterate in chronological order using the
+    # 'create_time' field.
+    items = list(mapping.values())
+    items.sort(key=lambda x: x.get('create_time', 0))
+    for item in items:
+        msg = item.get('message')
+        if not msg:
+            continue
+        content = msg.get('content', {})
+        parts = content.get('parts', [])
+        for part in parts:
+            yield part
+
+
+def write_conversation(conv, out_dir):
+    """Write a single conversation to a text file."""
+    title = conv.get('title', 'conversation')
+    mapping = conv.get('mapping', {})
+    outfile = Path(out_dir) / f"{title}.txt"
+    with outfile.open('w', encoding='utf-8') as f:
+        for part in extract_text_from_mapping(mapping):
+            f.write(part)
+            f.write('\n')
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('Usage: python parse_history.py export.json output_dir')
+        return
+    export_file = Path(sys.argv[1])
+    out_dir = Path(sys.argv[2])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = json.loads(export_file.read_text(encoding='utf-8'))
+    for conv in data.get('conversations', []):
+        write_conversation(conv, out_dir)
+    print(f"Wrote {len(data.get('conversations', []))} conversations to {out_dir}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `parse_history.py` to convert ChatGPT export JSON to plain text
- add `offline_bot.py` example to query local note files without web search
- document how to use the scripts in `README.md`

## Testing
- `python -m py_compile scripts/parse_history.py scripts/offline_bot.py`
