### PR TITLE
Add offline ChatGPT helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # ABDUL-QASSIM
+
+This repository contains example scripts for working with your own
+ChatGPT data and local text notes. The goal is to experiment with a
+completely offline workflow where a custom bot can answer questions
+using your personal knowledge base.
+
+## Getting your ChatGPT history
+
+1. In ChatGPT, open **Settings & Beta** → **Data Controls**.
+2. Choose **Export Data**. You will receive a ZIP archive containing a
+   JSON file with your conversation history.
+3. Unzip the archive and note the path to the `*.json` file.
+
+To convert the exported history into individual text files, run:
+
+```bash
+python scripts/parse_history.py path/to/conversations.json history/
+```
+
+This will create one text file per conversation under the `history/`
+directory. Titles are cleaned using a simple slugify routine so any
+problematic characters are replaced with underscores.
+
+## Using your own notes
+
+Place any `.txt` files you want the bot to reference inside a directory,
+e.g. `notes/`. Each file can contain sentences or bullet points.
+
+The `offline_bot.py` script performs a very simple keyword search across
+those files:
+
+```bash
+python scripts/offline_bot.py notes history "your question here"
+```
+
+The script prints the sentences that match all the keywords in your
+question. This is only a starting point. You can extend it with a local
+language model or embedding-based search to improve the quality of the
+answers.
+
+## Custom training
+
+If you wish to build a more advanced model, you can fine-tune an
+open-source language model (such as LLaMA, GPT-J, or similar) using your
+own dataset. The exported conversations and your notes can serve as the
+training data. Refer to the documentation of the model you choose for
+fine-tuning instructions.
+
+These scripts are intentionally lightweight so they can run without any
+network connection once the required Python packages are installed.

--- a/scripts/offline_bot.py
+++ b/scripts/offline_bot.py
@@ -1,0 +1,83 @@
+"""بوت بسيط للعمل بدون إنترنت
+------------------------------
+
+هالسكريبت يقرأ ملفات ``.txt`` اللي تحطها داخل مجلد محدد ويجاوب على أسئلتك
+باستخدام مطابقة كلمات مفتاحية فقط، من غير ما يعتمد على أي بحث بالويب.
+
+هو مو نموذج لغوي متكامل، بس تقدر تطوره وتدمج مكتبات مثل
+`sentence-transformers` لو حبيت.
+
+طريقة الاستخدام:
+
+```
+python offline_bot.py notes_dir history_dir "سؤالك هنا"
+```
+"""
+import sys
+from pathlib import Path
+import re
+
+
+def load_sentences(data_dirs):
+    """قراءة الجمل من مجلد أو أكثر يحتوي ملفات ``.txt``.
+
+    **المدخلات**:
+        - ``data_dirs`` (:class:`str` أو :class:`Path` أو ``list``): مسارات المجلدات.
+
+    **المخرجات**:
+        - قائمة من ``(اسم_الملف, الجملة)``.
+    """
+    if isinstance(data_dirs, (str, Path)):
+        dirs = [data_dirs]
+    else:
+        dirs = list(data_dirs)
+
+    sentences = []
+    for d in dirs:
+        for path in Path(d).rglob('*.txt'):
+            text = path.read_text(encoding='utf-8')
+            for line in text.splitlines():
+                line = line.strip()
+                if line:
+                    sentences.append((path.name, line))
+    return sentences
+
+
+def simple_search(sentences, query):
+    """بحث بسيط يطابق كل الكلمات المفتاحية.
+
+    **المدخلات**:
+        - ``sentences`` (:class:`list`): قائمة الجمل من ``load_sentences``.
+        - ``query`` (:class:`str`): سؤال المستخدم.
+
+    **المخرجات**:
+        - قائمة الجمل المطابقة.
+    """
+    keywords = re.findall(r"\w+", query.lower())
+    results = []
+    for name, sentence in sentences:
+        s_lower = sentence.lower()
+        if all(word in s_lower for word in keywords):
+            results.append((name, sentence))
+    return results
+
+
+def main():
+    """نقطة تشغيل السكربت."""
+
+    if len(sys.argv) < 3:
+        print('Usage: python offline_bot.py data_dir... "question"')
+        return
+    dirs = sys.argv[1:-1]
+    query = sys.argv[-1]
+    sentences = load_sentences(dirs)
+    results = simple_search(sentences, query)
+    if not results:
+        print('No results found.')
+    else:
+        for name, sentence in results[:5]:
+            print(f'[{name}] {sentence}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/parse_history.py
+++ b/scripts/parse_history.py
@@ -1,0 +1,111 @@
+"""تفاصيل السكربت
+------------------
+
+هذا السكربت يقرأ أرشيف محادثات ChatGPT اللي تصدره من الإعدادات عبر خيار
+"Export data". الملف المصدَّر يكون بصيغة JSON ونحوّله إلى ملفات نصية عادية
+حتى تستخدمها أو تدرب نماذجك بلا إنترنت.
+
+طريقة الاستخدام:
+
+```
+python parse_history.py path_to_export.json output_dir
+```
+
+عادةً هيكلية الملف تكون بهذا الشكل::
+
+    {
+        "conversations": [
+            {
+                "title": "مثال محادثة",
+                "mapping": { ... }
+            },
+            ...
+        ]
+    }
+
+الحقل ``mapping`` يحتوي الرسائل. السكربت يمشي على هالهيكل ويكتب كل محادثة
+داخل ``output_dir/<title>.txt``.
+
+ملاحظة: يحتاج بايثون 3.8 أو أحدث.
+"""
+import json
+import sys
+from pathlib import Path
+import re
+
+
+def slugify(name):
+    """تحويل العنوان إلى اسم ملف آمن.
+
+    **المدخلات**:
+        - ``name`` (:class:`str`): العنوان الأصلي.
+
+    **المخرجات**:
+        - الاسم بعد إزالة المحارف غير المناسبة.
+    """
+    slug = re.sub(r"[^\w-]+", "_", name).strip("_")
+    return slug or "conversation"
+
+def extract_text_from_mapping(mapping):
+    """استخراج رسائل المحادثة بالترتيب.
+
+    **المدخلات**:
+        - ``mapping`` (:class:`dict`): هيكل الرسائل كما يصدره ChatGPT.
+
+    **المخرجات**:
+        - يولد نص كل رسالة على حدة.
+
+    **ملاحظات**:
+        يمشي على الحقل ``create_time`` حتى يضمن الترتيب الصحيح.
+    """
+    # Each mapping entry is keyed by message ID with info about parent
+    # relationships. We iterate in chronological order using the
+    # 'create_time' field.
+    items = list(mapping.values())
+    items.sort(key=lambda x: x.get('create_time', 0))
+    for item in items:
+        msg = item.get('message')
+        if not msg:
+            continue
+        content = msg.get('content', {})
+        parts = content.get('parts', [])
+        for part in parts:
+            yield part
+
+
+def write_conversation(conv, out_dir):
+    """حفظ محادثة واحدة في ملف نصي.
+
+    **المدخلات**:
+        - ``conv`` (:class:`dict`): بيانات المحادثة.
+        - ``out_dir`` (:class:`Path`): المسار اللي راح نخزن به الملفات.
+
+    **المخرجات**:
+        - لا شيء، لكنه ينشئ ملفاً داخل ``out_dir``.
+    """
+    title = slugify(conv.get('title', 'conversation'))
+    mapping = conv.get('mapping', {})
+    outfile = Path(out_dir) / f"{title}.txt"
+    with outfile.open('w', encoding='utf-8') as f:
+        for part in extract_text_from_mapping(mapping):
+            f.write(part)
+            f.write('\n')
+
+
+def main():
+    """نقطة تشغيل السكربت."""
+
+    if len(sys.argv) != 3:
+        print('Usage: python parse_history.py export.json output_dir')
+        return
+    export_file = Path(sys.argv[1])
+    out_dir = Path(sys.argv[2])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = json.loads(export_file.read_text(encoding='utf-8'))
+    for conv in data.get('conversations', []):
+        write_conversation(conv, out_dir)
+    print(f"Wrote {len(data.get('conversations', []))} conversations to {out_dir}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_offline_bot.py
+++ b/tests/test_offline_bot.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from scripts import offline_bot
+
+
+def test_load_sentences(tmp_path):
+    f = tmp_path / 'note.txt'
+    f.write_text('hello\nworld', encoding='utf-8')
+    sentences = offline_bot.load_sentences(tmp_path)
+    assert sentences == [('note.txt', 'hello'), ('note.txt', 'world')]
+
+
+def test_load_sentences_multiple_dirs(tmp_path):
+    d1 = tmp_path / 'd1'
+    d2 = tmp_path / 'd2'
+    d1.mkdir()
+    d2.mkdir()
+    (d1 / 'a.txt').write_text('one', encoding='utf-8')
+    (d2 / 'b.txt').write_text('two', encoding='utf-8')
+    sentences = offline_bot.load_sentences([d1, d2])
+    assert ('a.txt', 'one') in sentences and ('b.txt', 'two') in sentences
+
+
+def test_simple_search():
+    sentences = [('note.txt', 'python rules'), ('note.txt', 'use snake case')]
+    result = offline_bot.simple_search(sentences, 'python')
+    assert result == [('note.txt', 'python rules')]
+    empty = offline_bot.simple_search(sentences, 'java')
+    assert empty == []
+

--- a/tests/test_parse_history.py
+++ b/tests/test_parse_history.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+from scripts import parse_history
+
+def test_extract_text_from_mapping():
+    mapping = {
+        '1': {'create_time': 1, 'message': {'content': {'parts': ['مرحبا']}}},
+        '2': {'create_time': 2, 'message': {'content': {'parts': ['هلا']}}},
+    }
+    texts = list(parse_history.extract_text_from_mapping(mapping))
+    assert texts == ['مرحبا', 'هلا']
+
+def test_write_conversation(tmp_path):
+    conv = {
+        'title': 'test',
+        'mapping': {
+            '1': {'create_time': 1, 'message': {'content': {'parts': ['اهلا']}}}
+        },
+    }
+    parse_history.write_conversation(conv, tmp_path)
+    text = (tmp_path / 'test.txt').read_text(encoding='utf-8').strip()
+    assert text == 'اهلا'
+
+
+def test_slugify_and_sanitized_filename(tmp_path):
+    conv = {
+        'title': 'my convo *1?',
+        'mapping': {
+            '1': {'create_time': 1, 'message': {'content': {'parts': ['hi']}}}
+        },
+    }
+    parse_history.write_conversation(conv, tmp_path)
+    files = list(tmp_path.iterdir())
+    assert files[0].name == 'my_convo_1.txt'
+


### PR DESCRIPTION
## Summary
- add `parse_history.py` to convert ChatGPT export JSON to plain text
- add `offline_bot.py` example to query local note files without web search
- document how to use the scripts in `README.md`
- sanitize conversation titles and allow searching multiple directories

## Testing
- `python -m py_compile scripts/parse_history.py scripts/offline_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6834d289af78832ea883703ac823ed14