### PR TITLE
codex/add-telegram-integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_BOT_TOKEN=your_bot_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ fine-tuning instructions.
 
 These scripts are intentionally lightweight so they can run without any
 network connection once the required Python packages are installed.
+
+## Connecting to Telegram
+
+To chat with your notes via Telegram, create a bot using [BotFather](https://t.me/BotFather)
+and copy the token. Create a `.env` file based on `.env.example` and place your token
+inside:
+
+```bash
+cp .env.example .env
+echo "TELEGRAM_BOT_TOKEN=your_token" >> .env
+```
+
+Run the Telegram bot with:
+
+```bash
+python scripts/telegram_bot.py notes/
+```
+
+Send any message to your bot, and it will search your notes using the same simple logic
+as `offline_bot.py`.

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -1,0 +1,66 @@
+"""
+telegram_bot.py
+---------------
+
+هذا السكربت يربط ملفاتك النصية ببوت تلغرام حتى تقدر تسأل ويجاوبك محلياً.
+لازم يكون عندك متغير البيئة `TELEGRAM_BOT_TOKEN` موجود حتى يشتغل البوت.
+
+الاستخدام:
+    python telegram_bot.py data_dir
+"""
+
+import os
+import sys
+from telegram.ext import Updater, MessageHandler, Filters
+
+from offline_bot import load_sentences, simple_search
+
+
+def handle_message(update, context):
+    """الغرض من هذه الدالة الرد على رسائل المستخدمين بطريقة بسيطة.
+
+    المدخلات:
+        update (telegram.Update): التحديث الوارد من تلغرام.
+        context (telegram.CallbackContext): السياق المصاحب للتحديث.
+    المخرجات:
+        لا يوجد. ترجع الرد مباشرة إلى المستخدم.
+    Notes: تعتمد على دالة `simple_search` للبحث بالكلمات.
+    """
+    query = update.message.text
+    results = simple_search(context.sentences, query)
+    if not results:
+        update.message.reply_text("ماكو نتائج، جرّب كلمات ثانية.")
+    else:
+        reply = "\n".join(
+            f"[{name}] {sentence}" for name, sentence in results[:5]
+        )
+        update.message.reply_text(reply)
+
+
+def main():
+    """تشغيل البوت بالتوصيل على الداتا دير وتوفير التوكن.
+
+    المدخلات: مسار المجلد الذي يحتوي على الملفات النصية.
+    المخرجات: لا شيء.
+    Notes: يجب ضبط متغير `TELEGRAM_BOT_TOKEN` في البيئة.
+    """
+    if len(sys.argv) != 2:
+        print("Usage: python telegram_bot.py data_dir")
+        return
+    data_dir = sys.argv[1]
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        print("Error: TELEGRAM_BOT_TOKEN not set")
+        return
+    updater = Updater(token)
+    sentences = load_sentences(data_dir)
+    updater.dispatcher.sentences = sentences
+    updater.dispatcher.add_handler(
+        MessageHandler(Filters.text & ~Filters.command, handle_message)
+    )
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_offline_bot.py
+++ b/tests/test_offline_bot.py
@@ -1,0 +1,35 @@
+import unittest
+from scripts.offline_bot import simple_search
+
+
+class TestSimpleSearch(unittest.TestCase):
+    """اختبارات دالة البحث البسيط.
+
+    تغطي الحالات الاعتيادية والخالية والخاطئة.
+    """
+
+    def setUp(self):
+        self.sentences = [
+            ("a.txt", "hello world"),
+            ("b.txt", "goodbye world"),
+        ]
+
+    def test_match(self):
+        """يجب إرجاع الجملة المطابقة."""
+        results = simple_search(self.sentences, "hello")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1], "hello world")
+
+    def test_no_match(self):
+        """بحث لا يعطي أي نتيجة."""
+        results = simple_search(self.sentences, "unknown")
+        self.assertEqual(results, [])
+
+    def test_empty_query(self):
+        """عند الاستعلام الفارغ يرجع كل الجمل."""
+        results = simple_search(self.sentences, "")
+        self.assertEqual(len(results), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add telegram bot script to query local notes
- document how to run the telegram integration
- provide example .env file and ignore secrets
- add unit tests for simple_search

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`

------
https://chatgpt.com/codex/tasks/task_e_683fa7f3b970832e9c6c011046adf627